### PR TITLE
Fixed links in syllabus

### DIFF
--- a/content/syllabus/_index.md
+++ b/content/syllabus/_index.md
@@ -23,8 +23,8 @@ you can write me to set-up a meeting via Zoom.
 ## Course Readings
 
 There will be no mandatory reading. However, weekly readings related to the
-[lectures](/lectures/) are strongly recommended, 
-and [additional ressources](/ressources/) 
+[lectures](/dsfba_2020/lectures/) are strongly recommended, 
+and [additional ressources](/dsfba_2020/ressources/) 
 will undoubtedly be useful.
 
 ## Evaluation


### PR DESCRIPTION
Not sure if the html should be autogenerated with root directory `dsfba_2020`, but in its current state the links are broken.